### PR TITLE
Install composer app deps as --no-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ RUN composer config platform.php ${PHP_VERSION}
 # Install Dependeinces
 ## * Platform requirments are checked at the later steps.
 ## * Scripts and Autoload are run at later steps.
-RUN composer install -n --no-progress --ignore-platform-reqs --no-plugins --no-scripts --no-autoloader --prefer-dist
+RUN composer install -n --no-progress --ignore-platform-reqs --no-plugins --no-scripts --no-autoloader --prefer-dist --no-dev
 
 # ======================================================================================================================
 # ==============================================  PRODUCTION IMAGE  ====================================================


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Hello, while trying to use your template for a laravel app, we hit an error while running `php artisan package:discover --ansi` ran by `entrypoint-base`

```
[2021-05-07 12:43:00] production.ERROR: Class 'Barryvdh\Debugbar\ServiceProvider' not found {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Class 'Barryvdh\\Debugbar\\ServiceProvider' not found at /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php:208)
[stacktrace]
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php(144): Illuminate\\Foundation\\ProviderRepository->createProvider()
#1 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php(61): Illuminate\\Foundation\\ProviderRepository->compileManifest()
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(584): Illuminate\\Foundation\\ProviderRepository->load()
#3 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php(17): Illuminate\\Foundation\\Application->registerConfiguredProviders()
#4 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(210): Illuminate\\Foundation\\Bootstrap\\RegisterProviders->bootstrap()
#5 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(322): Illuminate\\Foundation\\Application->bootstrapWith()
#6 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(131): Illuminate\\Foundation\\Console\\Kernel->bootstrap()
#7 /var/www/html/artisan(37): Illuminate\\Foundation\\Console\\Kernel->handle()
#8 {main}
"} 

In ProviderRepository.php line 208:
                                                       
  Class 'Barryvdh\Debugbar\ServiceProvider' not found  
                                                       
```

It's because laravel looks for service providers declared in `vendor/composer/install.json` when running `php artisan package:discover --ansi`. It's generated by `RUN composer install -n --no-progress --ignore-platform-reqs --no-plugins --no-scripts --no-autoloader --prefer-dist` command and installs dev deps.

However since autoload is generated as --no-dev, while trying to access a class declared in `vendor/composer/install.json` that includes dev classes, it fails.

Since dev stage execute composer install again, it seems this change won't produce any collateral damages.


Where has this been tested?
---------------------------
local
